### PR TITLE
Report & hilight "skipped". Fix section collapse.

### DIFF
--- a/src/nose_htmloutput/templates/report.html
+++ b/src/nose_htmloutput/templates/report.html
@@ -49,6 +49,9 @@ h3 strong, a.failed {
 a.success {
     color: #3d9970;
 }
+a.skipped {
+    color: #000000;
+}
 pre {
     font-family: 'Consolas', 'Deja Vu Sans Mono',
                  'Bitstream Vera Sans Mono', 'Monaco',
@@ -97,41 +100,47 @@ section:target .test-details {
             </tr>
         </table>
     </section>
+	
     <h1>Failure details</h1>
-    {% for class, group in report.items() %}
-        {% if group.stats.failures or group.stats.errors %}
-            <section>
-                <h2>{{ class }} ({{ group.stats.failures }} failures, {{ group.stats.errors }} errors)</h2>
-                <div>
-                    {% for test in group.tests %}
-                        {% if test.failed and test.type != 'skipped' %}
-                        <section id="{{ class }}:{{ test.name }}">
-                            <h3>{{ test.name }}: <strong>{{ test.errtype }}</strong></h3>
-                            <div class="test-details">
-                                <h4>Traceback</h4>
-                                <pre class="traceback">{{ test.tb }}</pre>
-                                <h4>Details</h4>
-                                <pre>{{ test.message }}</pre>
-                            </div>
-                        </section>
-                        {% endif %}
-                    {% endfor %}
-                </div>
-            </section>
-        {% endif %}
-    {% endfor %}
+	<section>
+		{% for class, group in report.items() %}
+			{% if group.stats.failures or group.stats.errors %}
+				<section>
+					<h2>{{ class }} ({{ group.stats.failures }} failures, {{ group.stats.errors }} errors)</h2>
+					<div>
+						{% for test in group.tests %}
+							{% if test.failed and test.type != 'skipped' %}
+							<section id="{{ class }}:{{ test.name }}">
+								<h3>{{ test.name }}: <strong>{{ test.errtype }}</strong></h3>
+								<div class="test-details">
+									<h4>Traceback</h4>
+									<pre class="traceback">{{ test.tb }}</pre>
+									<h4>Details</h4>
+									<pre>{{ test.message }}</pre>
+								</div>
+							</section>
+							{% endif %}
+						{% endfor %}
+					</div>
+				</section>
+			{% endif %}
+		{% endfor %}
+	</section>
 
     <h1>All tests</h1>
-    {% for class, group in report.items() %}
-    <section>
-        <h2>{{ class }} ({{ group.stats.failures }} failures, {{ group.stats.errors }} errors)</h2>
-        <ul>
-            {% for test in group.tests %}
-                <li><a class="{% if test.failed %}failed" href="#{{ class }}:{{ test.name }}"{% else %}success"{% endif %}>{{ test.name }}</a></li>
-            {% endfor %}
-        </ul>
-    </section>
-    {% endfor %}
+	<section>
+		{% for class, group in report.items() %}
+			<section>
+				<h2>{{ class }} ({{ group.stats.failures }} failures, {{ group.stats.errors }} errors, {{ group.stats.skipped }} skips)</h2>
+				<ul>
+					{% for test in group.tests %}
+						<li><a class="{% if test.failed %}{% if test.type == 'skipped'%}skipped"{% else %}failed" href="#{{ class }}:{{ test.name }}"{% endif %}{% else %}success"{% endif %}>{{ test.name }}</a></li>
+					{% endfor %}
+				</ul>
+			</section>
+		{% endfor %}
+	</section>
+
 </body>
 <script>
     Array.prototype.forEach.call(document.querySelectorAll('h1, h2, h3, h4'), function(el) {


### PR DESCRIPTION
Wrap the "Failure Details" and "All tests" sections with `<section>` so that they collapse correctly. Previously only the 1st box would collapse.

Also report skipped tests in the "All tests" section, using a different color
