### PR TITLE
Escape HTML in test output

### DIFF
--- a/src/nose_htmloutput/templates/report.html
+++ b/src/nose_htmloutput/templates/report.html
@@ -109,9 +109,9 @@ section:target .test-details {
                             <h3>{{ test.name }}: <strong>{{ test.errtype }}</strong></h3>
                             <div class="test-details">
                                 <h4>Traceback</h4>
-                                <pre class="traceback">{{ test.tb }}</pre>
+                                <pre class="traceback">{{ test.tb | e }}</pre>
                                 <h4>Details</h4>
-                                <pre>{{ test.message }}</pre>
+                                <pre>{{ test.message | e }}</pre>
                             </div>
                         </section>
                         {% endif %}


### PR DESCRIPTION
Tests that include HTML will currently not display correctly on the report.

```
'test' != 'test<h2>'
```

will appear on the report as

```
'test' != 'test
'
```

This change escapes HTML in test output so that the report is correct.
